### PR TITLE
Improve evdev keyboard detection

### DIFF
--- a/evdev.py
+++ b/evdev.py
@@ -93,7 +93,7 @@ def find_devices(joystick=False):
 			handlers = l.split("=",1)[-1].split()
 		elif l.startswith("B: EV="):
 			ev = l.split("=",1)[-1]
-			if (ev == "120013" and not joystick) or (ev.endswith("1b") and joystick):
+			if ((int(ev, 16) & 0x120003) == 0x120003 and not joystick) or (ev.endswith("1b") and joystick):
 				if joystick and not "js0" in handlers:
 					continue
 				print("Found device: {}".format(name))


### PR DESCRIPTION
It now detects the Corsair K95 (with EV == 0x120003) and Logitech K400 (with EV == 0x12001f)